### PR TITLE
new version of iPlastic

### DIFF
--- a/Themes/iPlastic.tmTheme
+++ b/Themes/iPlastic.tmTheme
@@ -12,7 +12,7 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EEEEEEEB</string>
+				<string>#EEEEEE</string>
 				<key>caret</key>
 				<string>#000000</string>
 				<key>foreground</key>


### PR DESCRIPTION
TM2 has no support for transparent backgrounds yet, and it creates some terrible ghosting, so we're making it non-transparent for now.
