### PR TITLE
Add gutter styling to Blackboard theme

### DIFF
--- a/Themes/Blackboard.tmTheme
+++ b/Themes/Blackboard.tmTheme
@@ -17,6 +17,10 @@
 				<string>#FFFFFFA6</string>
 				<key>foreground</key>
 				<string>#F8F8F8</string>
+				<key>gutterDivider</key>
+				<string>#0C1021</string>
+				<key>gutterSelectionBorder</key>
+				<string>#0C1021</string>
 				<key>invisibles</key>
 				<string>#FFFFFF40</string>
 				<key>lineHighlight</key>


### PR DESCRIPTION
A recent Textmate update added gutter styling keys; this restyled the gutters kind of haphazardly, and the Blackboard gutter styling was much busier. This change makes the styling more reasonable.

Before this commit: https://dl.dropbox.com/u/4414866/Screenshots/textmate_blackboard_before.png

After this commit: https://dl.dropbox.com/u/4414866/Screenshots/textmate_blackboard_after.png
