### PR TITLE
Insert Menlo as monospace font after Bitstream Vera Sans Mono

### DIFF
--- a/Support/web-themes/default/style.css
+++ b/Support/web-themes/default/style.css
@@ -140,7 +140,7 @@ blockquote {
 
 code, pre {
 	font-size: 95%;
-	font-family: "LuxiMono", "Bitstream Vera Sans Mono", "Monaco", "Courier New", monospace;
+	font-family: "LuxiMono", "Bitstream Vera Sans Mono", "Menlo", "Monaco", "Courier New", monospace;
 	word-wrap: break-word;
 	white-space: pre;
 	white-space: pre-wrap;


### PR DESCRIPTION
Looks similar (a fork of it), and is the default monospace font on newer OS X
