### PR TITLE
Add styling for <kbd> tags in web themes.

### DIFF
--- a/Support/web-themes/dark/style.css
+++ b/Support/web-themes/dark/style.css
@@ -37,6 +37,12 @@
 	border: 1px solid #555;
 }
 
+.dark kbd {
+  background-color: #3d3f3f;
+  color: #cbc8cd;
+  border: 1px solid #55585a;
+  box-shadow: inset 0 -1px 0 #525456;
+}
 
 .dark .pro_table {
 	border-top: 1px solid #616465;

--- a/Support/web-themes/default/style.css
+++ b/Support/web-themes/default/style.css
@@ -138,9 +138,11 @@ blockquote {
 	padding-left: 1em;
 }
 
-code, pre {
+code, pre, kbd {
 	font-size: 95%;
 	font-family: "LuxiMono", "Bitstream Vera Sans Mono", "Menlo", "Monaco", "Courier New", monospace;
+}
+code, pre {
 	word-wrap: break-word;
 	white-space: pre;
 	white-space: pre-wrap;
@@ -150,6 +152,19 @@ code, pre {
 
 pre {
 	padding: 10px 10px 10px 20px;
+}
+
+kbd {
+  display: inline-block;
+  padding: 0px 3px;
+  letter-spacing: 1px;
+  color: #444d56;
+  vertical-align: middle;
+  background-color: #fafbfc;
+  border: solid 1px #c6cbd1;
+  border-bottom-color: #959da5;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #959da5;
 }
 
 .pro_table {

--- a/Support/web-themes/halloween/style.css
+++ b/Support/web-themes/halloween/style.css
@@ -51,6 +51,12 @@
 	border: 1px solid #555;
 }
 
+.halloween kbd {
+  background-color: #3d3f3f;
+  color: #e9c534;
+  border: 1px solid #55585a;
+  box-shadow: inset 0 -1px 0 #525456;
+}
 
 .halloween .pro_table {
 	border-top: 1px solid #616465;

--- a/Support/web-themes/night/style.css
+++ b/Support/web-themes/night/style.css
@@ -39,6 +39,13 @@
 	background-color: #111;
 }
 
+.night kbd {
+  background-color: #3d3f3f;
+  color: #bbb;
+  border: 1px solid #55585a;
+  box-shadow: inset 0 -1px 0 #525456;
+}
+
 .night .pro_table {
 	border-top: 1px solid #616465;
 	border-left: 1px solid #616465;

--- a/Support/web-themes/plain/style.css
+++ b/Support/web-themes/plain/style.css
@@ -135,6 +135,9 @@ body.plain {
   white-space: pre;
   word-wrap: normal;
 }
+.plain kbd {
+  font-size: 95%;
+}
 .plain hr {
   background-color: #e0e0e0;
   border: none;

--- a/Support/web-themes/shiny/style.css
+++ b/Support/web-themes/shiny/style.css
@@ -37,6 +37,12 @@
 	border: 1px solid #555;
 }
 
+.shiny kbd {
+  background-color: #3d3f3f;
+  color: #cbc8cd;
+  border: 1px solid #55585a;
+  box-shadow: inset 0 -1px 0 #525456;
+}
 
 .shiny .pro_table {
 	border-top: 1px solid #616465;


### PR DESCRIPTION
The styling is very similar to how GitHub styles <kbd> tags (for dark themes it has been adapted accordingly).